### PR TITLE
Fixed README.md files, replacing POSTGRES_DATABASE with POSTGRES_DB

### DIFF
--- a/9.0-2.1/README.md
+++ b/9.0-2.1/README.md
@@ -10,7 +10,7 @@ base image (9.0-9.4).
 
 This image ensures that the default database created by the parent `postgres`
 image will have the `postgis` and `postgis_topology` extensions installed.
-Unless `-e POSTGRES_DATABASE` is passed to the container at startup time, this
+Unless `-e POSTGRES_DB` is passed to the container at startup time, this
 database will be named after the admin user (either `postgres` or the user
 specified with `-e POSTGRES_USER`). For Postgres 9.1+, the `fuzzystrmatch` and
 `postgis_tiger_geocoder` extensions are also installed.

--- a/9.1-2.1/README.md
+++ b/9.1-2.1/README.md
@@ -10,7 +10,7 @@ base image (9.0-9.4).
 
 This image ensures that the default database created by the parent `postgres`
 image will have the `postgis` and `postgis_topology` extensions installed.
-Unless `-e POSTGRES_DATABASE` is passed to the container at startup time, this
+Unless `-e POSTGRES_DB` is passed to the container at startup time, this
 database will be named after the admin user (either `postgres` or the user
 specified with `-e POSTGRES_USER`). For Postgres 9.1+, the `fuzzystrmatch` and
 `postgis_tiger_geocoder` extensions are also installed.

--- a/9.2-2.1/README.md
+++ b/9.2-2.1/README.md
@@ -10,7 +10,7 @@ base image (9.0-9.4).
 
 This image ensures that the default database created by the parent `postgres`
 image will have the `postgis` and `postgis_topology` extensions installed.
-Unless `-e POSTGRES_DATABASE` is passed to the container at startup time, this
+Unless `-e POSTGRES_DB` is passed to the container at startup time, this
 database will be named after the admin user (either `postgres` or the user
 specified with `-e POSTGRES_USER`). For Postgres 9.1+, the `fuzzystrmatch` and
 `postgis_tiger_geocoder` extensions are also installed.

--- a/9.3-2.1/README.md
+++ b/9.3-2.1/README.md
@@ -10,7 +10,7 @@ base image (9.0-9.4).
 
 This image ensures that the default database created by the parent `postgres`
 image will have the `postgis` and `postgis_topology` extensions installed.
-Unless `-e POSTGRES_DATABASE` is passed to the container at startup time, this
+Unless `-e POSTGRES_DB` is passed to the container at startup time, this
 database will be named after the admin user (either `postgres` or the user
 specified with `-e POSTGRES_USER`). For Postgres 9.1+, the `fuzzystrmatch` and
 `postgis_tiger_geocoder` extensions are also installed.

--- a/9.4-2.1/README.md
+++ b/9.4-2.1/README.md
@@ -10,7 +10,7 @@ base image (9.0-9.4).
 
 This image ensures that the default database created by the parent `postgres`
 image will have the `postgis` and `postgis_topology` extensions installed.
-Unless `-e POSTGRES_DATABASE` is passed to the container at startup time, this
+Unless `-e POSTGRES_DB` is passed to the container at startup time, this
 database will be named after the admin user (either `postgres` or the user
 specified with `-e POSTGRES_USER`). For Postgres 9.1+, the `fuzzystrmatch` and
 `postgis_tiger_geocoder` extensions are also installed.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ base image (9.0-9.4).
 
 This image ensures that the default database created by the parent `postgres`
 image will have the `postgis` and `postgis_topology` extensions installed.
-Unless `-e POSTGRES_DATABASE` is passed to the container at startup time, this
+Unless `-e POSTGRES_DB` is passed to the container at startup time, this
 database will be named after the admin user (either `postgres` or the user
 specified with `-e POSTGRES_USER`). For Postgres 9.1+, the `fuzzystrmatch` and
 `postgis_tiger_geocoder` extensions are also installed.


### PR DESCRIPTION
The README is wrong, stating that you can set up a database by passing `-e POSTGRES_DATABASE` to docker. But `initdb-postgis.sh` uses `POSTGRES_DB`.