### PR TITLE
Remove 9.0 Supporting Code in initdb-postgres.sh

### DIFF
--- a/9.1-2.2/initdb-postgis.sh
+++ b/9.1-2.2/initdb-postgis.sh
@@ -12,28 +12,12 @@ UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB
-cd "/usr/share/postgresql/$PG_MAJOR/contrib/postgis-$POSTGIS_MAJOR"
 for DB in template_postgis "$POSTGRES_DB"; do
-	if awk "BEGIN { exit $PG_MAJOR >= 9.1 ? 0 : 1 }"; then
-		echo "Loading PostGIS into $DB via CREATE EXTENSION"
-		psql --dbname="$DB" <<-'EOSQL'
-			CREATE EXTENSION postgis;
-			CREATE EXTENSION postgis_topology;
-			CREATE EXTENSION fuzzystrmatch;
-			CREATE EXTENSION postgis_tiger_geocoder;
-		EOSQL
-	else
-		echo "Loading PostGIS into $DB via files"
-		files='
-			postgis
-			postgis_comments
-			topology
-			topology_comments
-			rtpostgis
-			raster_comments
-		'
-		for file in $files; do
-			psql --dbname="$DB" < "${file}.sql"
-		done
-	fi
+    echo "Loading PostGIS extensions into $DB"
+    psql --dbname="$DB" <<-'EOSQL'
+        CREATE EXTENSION postgis;
+        CREATE EXTENSION postgis_topology;
+        CREATE EXTENSION fuzzystrmatch;
+        CREATE EXTENSION postgis_tiger_geocoder;
+EOSQL
 done

--- a/9.1-2.2/initdb-postgis.sh
+++ b/9.1-2.2/initdb-postgis.sh
@@ -13,11 +13,11 @@ EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB
 for DB in template_postgis "$POSTGRES_DB"; do
-    echo "Loading PostGIS extensions into $DB"
-    psql --dbname="$DB" <<-'EOSQL'
-        CREATE EXTENSION postgis;
-        CREATE EXTENSION postgis_topology;
-        CREATE EXTENSION fuzzystrmatch;
-        CREATE EXTENSION postgis_tiger_geocoder;
+	echo "Loading PostGIS extensions into $DB"
+	psql --dbname="$DB" <<-'EOSQL'
+		CREATE EXTENSION postgis;
+		CREATE EXTENSION postgis_topology;
+		CREATE EXTENSION fuzzystrmatch;
+		CREATE EXTENSION postgis_tiger_geocoder;
 EOSQL
 done

--- a/9.2-2.2/initdb-postgis.sh
+++ b/9.2-2.2/initdb-postgis.sh
@@ -12,28 +12,12 @@ UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB
-cd "/usr/share/postgresql/$PG_MAJOR/contrib/postgis-$POSTGIS_MAJOR"
 for DB in template_postgis "$POSTGRES_DB"; do
-	if awk "BEGIN { exit $PG_MAJOR >= 9.1 ? 0 : 1 }"; then
-		echo "Loading PostGIS into $DB via CREATE EXTENSION"
-		psql --dbname="$DB" <<-'EOSQL'
-			CREATE EXTENSION postgis;
-			CREATE EXTENSION postgis_topology;
-			CREATE EXTENSION fuzzystrmatch;
-			CREATE EXTENSION postgis_tiger_geocoder;
-		EOSQL
-	else
-		echo "Loading PostGIS into $DB via files"
-		files='
-			postgis
-			postgis_comments
-			topology
-			topology_comments
-			rtpostgis
-			raster_comments
-		'
-		for file in $files; do
-			psql --dbname="$DB" < "${file}.sql"
-		done
-	fi
+    echo "Loading PostGIS extensions into $DB"
+    psql --dbname="$DB" <<-'EOSQL'
+        CREATE EXTENSION postgis;
+        CREATE EXTENSION postgis_topology;
+        CREATE EXTENSION fuzzystrmatch;
+        CREATE EXTENSION postgis_tiger_geocoder;
+EOSQL
 done

--- a/9.2-2.2/initdb-postgis.sh
+++ b/9.2-2.2/initdb-postgis.sh
@@ -13,11 +13,11 @@ EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB
 for DB in template_postgis "$POSTGRES_DB"; do
-    echo "Loading PostGIS extensions into $DB"
-    psql --dbname="$DB" <<-'EOSQL'
-        CREATE EXTENSION postgis;
-        CREATE EXTENSION postgis_topology;
-        CREATE EXTENSION fuzzystrmatch;
-        CREATE EXTENSION postgis_tiger_geocoder;
+	echo "Loading PostGIS extensions into $DB"
+	psql --dbname="$DB" <<-'EOSQL'
+		CREATE EXTENSION postgis;
+		CREATE EXTENSION postgis_topology;
+		CREATE EXTENSION fuzzystrmatch;
+		CREATE EXTENSION postgis_tiger_geocoder;
 EOSQL
 done

--- a/9.3-2.2/initdb-postgis.sh
+++ b/9.3-2.2/initdb-postgis.sh
@@ -12,28 +12,12 @@ UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB
-cd "/usr/share/postgresql/$PG_MAJOR/contrib/postgis-$POSTGIS_MAJOR"
 for DB in template_postgis "$POSTGRES_DB"; do
-	if awk "BEGIN { exit $PG_MAJOR >= 9.1 ? 0 : 1 }"; then
-		echo "Loading PostGIS into $DB via CREATE EXTENSION"
-		psql --dbname="$DB" <<-'EOSQL'
-			CREATE EXTENSION postgis;
-			CREATE EXTENSION postgis_topology;
-			CREATE EXTENSION fuzzystrmatch;
-			CREATE EXTENSION postgis_tiger_geocoder;
-		EOSQL
-	else
-		echo "Loading PostGIS into $DB via files"
-		files='
-			postgis
-			postgis_comments
-			topology
-			topology_comments
-			rtpostgis
-			raster_comments
-		'
-		for file in $files; do
-			psql --dbname="$DB" < "${file}.sql"
-		done
-	fi
+    echo "Loading PostGIS extensions into $DB"
+    psql --dbname="$DB" <<-'EOSQL'
+        CREATE EXTENSION postgis;
+        CREATE EXTENSION postgis_topology;
+        CREATE EXTENSION fuzzystrmatch;
+        CREATE EXTENSION postgis_tiger_geocoder;
+EOSQL
 done

--- a/9.3-2.2/initdb-postgis.sh
+++ b/9.3-2.2/initdb-postgis.sh
@@ -13,11 +13,11 @@ EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB
 for DB in template_postgis "$POSTGRES_DB"; do
-    echo "Loading PostGIS extensions into $DB"
-    psql --dbname="$DB" <<-'EOSQL'
-        CREATE EXTENSION postgis;
-        CREATE EXTENSION postgis_topology;
-        CREATE EXTENSION fuzzystrmatch;
-        CREATE EXTENSION postgis_tiger_geocoder;
+	echo "Loading PostGIS extensions into $DB"
+	psql --dbname="$DB" <<-'EOSQL'
+		CREATE EXTENSION postgis;
+		CREATE EXTENSION postgis_topology;
+		CREATE EXTENSION fuzzystrmatch;
+		CREATE EXTENSION postgis_tiger_geocoder;
 EOSQL
 done

--- a/9.4-2.2/initdb-postgis.sh
+++ b/9.4-2.2/initdb-postgis.sh
@@ -12,28 +12,12 @@ UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB
-cd "/usr/share/postgresql/$PG_MAJOR/contrib/postgis-$POSTGIS_MAJOR"
 for DB in template_postgis "$POSTGRES_DB"; do
-	if awk "BEGIN { exit $PG_MAJOR >= 9.1 ? 0 : 1 }"; then
-		echo "Loading PostGIS into $DB via CREATE EXTENSION"
-		psql --dbname="$DB" <<-'EOSQL'
-			CREATE EXTENSION postgis;
-			CREATE EXTENSION postgis_topology;
-			CREATE EXTENSION fuzzystrmatch;
-			CREATE EXTENSION postgis_tiger_geocoder;
-		EOSQL
-	else
-		echo "Loading PostGIS into $DB via files"
-		files='
-			postgis
-			postgis_comments
-			topology
-			topology_comments
-			rtpostgis
-			raster_comments
-		'
-		for file in $files; do
-			psql --dbname="$DB" < "${file}.sql"
-		done
-	fi
+    echo "Loading PostGIS extensions into $DB"
+    psql --dbname="$DB" <<-'EOSQL'
+        CREATE EXTENSION postgis;
+        CREATE EXTENSION postgis_topology;
+        CREATE EXTENSION fuzzystrmatch;
+        CREATE EXTENSION postgis_tiger_geocoder;
+EOSQL
 done

--- a/9.4-2.2/initdb-postgis.sh
+++ b/9.4-2.2/initdb-postgis.sh
@@ -13,11 +13,11 @@ EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB
 for DB in template_postgis "$POSTGRES_DB"; do
-    echo "Loading PostGIS extensions into $DB"
-    psql --dbname="$DB" <<-'EOSQL'
-        CREATE EXTENSION postgis;
-        CREATE EXTENSION postgis_topology;
-        CREATE EXTENSION fuzzystrmatch;
-        CREATE EXTENSION postgis_tiger_geocoder;
+	echo "Loading PostGIS extensions into $DB"
+	psql --dbname="$DB" <<-'EOSQL'
+		CREATE EXTENSION postgis;
+		CREATE EXTENSION postgis_topology;
+		CREATE EXTENSION fuzzystrmatch;
+		CREATE EXTENSION postgis_tiger_geocoder;
 EOSQL
 done

--- a/9.5-2.2/initdb-postgis.sh
+++ b/9.5-2.2/initdb-postgis.sh
@@ -12,28 +12,12 @@ UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB
-cd "/usr/share/postgresql/$PG_MAJOR/contrib/postgis-$POSTGIS_MAJOR"
 for DB in template_postgis "$POSTGRES_DB"; do
-	if awk "BEGIN { exit $PG_MAJOR >= 9.1 ? 0 : 1 }"; then
-		echo "Loading PostGIS into $DB via CREATE EXTENSION"
-		psql --dbname="$DB" <<-'EOSQL'
-			CREATE EXTENSION postgis;
-			CREATE EXTENSION postgis_topology;
-			CREATE EXTENSION fuzzystrmatch;
-			CREATE EXTENSION postgis_tiger_geocoder;
-		EOSQL
-	else
-		echo "Loading PostGIS into $DB via files"
-		files='
-			postgis
-			postgis_comments
-			topology
-			topology_comments
-			rtpostgis
-			raster_comments
-		'
-		for file in $files; do
-			psql --dbname="$DB" < "${file}.sql"
-		done
-	fi
+    echo "Loading PostGIS extensions into $DB"
+    psql --dbname="$DB" <<-'EOSQL'
+        CREATE EXTENSION postgis;
+        CREATE EXTENSION postgis_topology;
+        CREATE EXTENSION fuzzystrmatch;
+        CREATE EXTENSION postgis_tiger_geocoder;
+EOSQL
 done

--- a/9.5-2.2/initdb-postgis.sh
+++ b/9.5-2.2/initdb-postgis.sh
@@ -13,11 +13,11 @@ EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB
 for DB in template_postgis "$POSTGRES_DB"; do
-    echo "Loading PostGIS extensions into $DB"
-    psql --dbname="$DB" <<-'EOSQL'
-        CREATE EXTENSION postgis;
-        CREATE EXTENSION postgis_topology;
-        CREATE EXTENSION fuzzystrmatch;
-        CREATE EXTENSION postgis_tiger_geocoder;
+	echo "Loading PostGIS extensions into $DB"
+	psql --dbname="$DB" <<-'EOSQL'
+		CREATE EXTENSION postgis;
+		CREATE EXTENSION postgis_topology;
+		CREATE EXTENSION fuzzystrmatch;
+		CREATE EXTENSION postgis_tiger_geocoder;
 EOSQL
 done

--- a/initdb-postgis.sh
+++ b/initdb-postgis.sh
@@ -12,28 +12,12 @@ UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB
-cd "/usr/share/postgresql/$PG_MAJOR/contrib/postgis-$POSTGIS_MAJOR"
 for DB in template_postgis "$POSTGRES_DB"; do
-	if awk "BEGIN { exit $PG_MAJOR >= 9.1 ? 0 : 1 }"; then
-		echo "Loading PostGIS into $DB via CREATE EXTENSION"
-		psql --dbname="$DB" <<-'EOSQL'
-			CREATE EXTENSION postgis;
-			CREATE EXTENSION postgis_topology;
-			CREATE EXTENSION fuzzystrmatch;
-			CREATE EXTENSION postgis_tiger_geocoder;
-		EOSQL
-	else
-		echo "Loading PostGIS into $DB via files"
-		files='
-			postgis
-			postgis_comments
-			topology
-			topology_comments
-			rtpostgis
-			raster_comments
-		'
-		for file in $files; do
-			psql --dbname="$DB" < "${file}.sql"
-		done
-	fi
+    echo "Loading PostGIS extensions into $DB"
+    psql --dbname="$DB" <<-'EOSQL'
+        CREATE EXTENSION postgis;
+        CREATE EXTENSION postgis_topology;
+        CREATE EXTENSION fuzzystrmatch;
+        CREATE EXTENSION postgis_tiger_geocoder;
+EOSQL
 done

--- a/initdb-postgis.sh
+++ b/initdb-postgis.sh
@@ -13,11 +13,11 @@ EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB
 for DB in template_postgis "$POSTGRES_DB"; do
-    echo "Loading PostGIS extensions into $DB"
-    psql --dbname="$DB" <<-'EOSQL'
-        CREATE EXTENSION postgis;
-        CREATE EXTENSION postgis_topology;
-        CREATE EXTENSION fuzzystrmatch;
-        CREATE EXTENSION postgis_tiger_geocoder;
+	echo "Loading PostGIS extensions into $DB"
+	psql --dbname="$DB" <<-'EOSQL'
+		CREATE EXTENSION postgis;
+		CREATE EXTENSION postgis_topology;
+		CREATE EXTENSION fuzzystrmatch;
+		CREATE EXTENSION postgis_tiger_geocoder;
 EOSQL
 done


### PR DESCRIPTION
Since only >=9.1 is supported now, we can always load postgis via extensions.