### PR TITLE
Use psql variable from entrypoint

### DIFF
--- a/9.1-2.2/initdb-postgis.sh
+++ b/9.1-2.2/initdb-postgis.sh
@@ -6,7 +6,7 @@ set -e
 export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
-psql --dbname="$POSTGRES_DB" <<- 'EOSQL'
+"${psql[@]}" <<- 'EOSQL'
 CREATE DATABASE template_postgis;
 UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
 EOSQL
@@ -14,7 +14,7 @@ EOSQL
 # Load PostGIS into both template_database and $POSTGRES_DB
 for DB in template_postgis "$POSTGRES_DB"; do
 	echo "Loading PostGIS extensions into $DB"
-	psql --dbname="$DB" <<-'EOSQL'
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION postgis;
 		CREATE EXTENSION postgis_topology;
 		CREATE EXTENSION fuzzystrmatch;

--- a/9.2-2.2/initdb-postgis.sh
+++ b/9.2-2.2/initdb-postgis.sh
@@ -6,7 +6,7 @@ set -e
 export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
-psql --dbname="$POSTGRES_DB" <<- 'EOSQL'
+"${psql[@]}" <<- 'EOSQL'
 CREATE DATABASE template_postgis;
 UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
 EOSQL
@@ -14,7 +14,7 @@ EOSQL
 # Load PostGIS into both template_database and $POSTGRES_DB
 for DB in template_postgis "$POSTGRES_DB"; do
 	echo "Loading PostGIS extensions into $DB"
-	psql --dbname="$DB" <<-'EOSQL'
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION postgis;
 		CREATE EXTENSION postgis_topology;
 		CREATE EXTENSION fuzzystrmatch;

--- a/9.3-2.2/initdb-postgis.sh
+++ b/9.3-2.2/initdb-postgis.sh
@@ -6,7 +6,7 @@ set -e
 export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
-psql --dbname="$POSTGRES_DB" <<- 'EOSQL'
+"${psql[@]}" <<- 'EOSQL'
 CREATE DATABASE template_postgis;
 UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
 EOSQL
@@ -14,7 +14,7 @@ EOSQL
 # Load PostGIS into both template_database and $POSTGRES_DB
 for DB in template_postgis "$POSTGRES_DB"; do
 	echo "Loading PostGIS extensions into $DB"
-	psql --dbname="$DB" <<-'EOSQL'
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION postgis;
 		CREATE EXTENSION postgis_topology;
 		CREATE EXTENSION fuzzystrmatch;

--- a/9.4-2.2/initdb-postgis.sh
+++ b/9.4-2.2/initdb-postgis.sh
@@ -6,7 +6,7 @@ set -e
 export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
-psql --dbname="$POSTGRES_DB" <<- 'EOSQL'
+"${psql[@]}" <<- 'EOSQL'
 CREATE DATABASE template_postgis;
 UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
 EOSQL
@@ -14,7 +14,7 @@ EOSQL
 # Load PostGIS into both template_database and $POSTGRES_DB
 for DB in template_postgis "$POSTGRES_DB"; do
 	echo "Loading PostGIS extensions into $DB"
-	psql --dbname="$DB" <<-'EOSQL'
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION postgis;
 		CREATE EXTENSION postgis_topology;
 		CREATE EXTENSION fuzzystrmatch;

--- a/9.5-2.2/initdb-postgis.sh
+++ b/9.5-2.2/initdb-postgis.sh
@@ -6,7 +6,7 @@ set -e
 export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
-psql --dbname="$POSTGRES_DB" <<- 'EOSQL'
+"${psql[@]}" <<- 'EOSQL'
 CREATE DATABASE template_postgis;
 UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
 EOSQL
@@ -14,7 +14,7 @@ EOSQL
 # Load PostGIS into both template_database and $POSTGRES_DB
 for DB in template_postgis "$POSTGRES_DB"; do
 	echo "Loading PostGIS extensions into $DB"
-	psql --dbname="$DB" <<-'EOSQL'
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION postgis;
 		CREATE EXTENSION postgis_topology;
 		CREATE EXTENSION fuzzystrmatch;

--- a/initdb-postgis.sh
+++ b/initdb-postgis.sh
@@ -6,7 +6,7 @@ set -e
 export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
-psql --dbname="$POSTGRES_DB" <<- 'EOSQL'
+"${psql[@]}" <<- 'EOSQL'
 CREATE DATABASE template_postgis;
 UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
 EOSQL
@@ -14,7 +14,7 @@ EOSQL
 # Load PostGIS into both template_database and $POSTGRES_DB
 for DB in template_postgis "$POSTGRES_DB"; do
 	echo "Loading PostGIS extensions into $DB"
-	psql --dbname="$DB" <<-'EOSQL'
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION postgis;
 		CREATE EXTENSION postgis_topology;
 		CREATE EXTENSION fuzzystrmatch;


### PR DESCRIPTION
Using the `psql` variable defined in the entrypoint ensures that `initdb-postgis.sh` connects to postgres properly no matter how postgres is setup. For example, if the port needs to be changed in the entrypoint, it won't have to be changed in all initdb scripts if they use the `psql` variable properly.