### PR TITLE
add IF NOT EXISTS to CREATE EXTENSION

### DIFF
--- a/9.1-2.2/initdb-postgis.sh
+++ b/9.1-2.2/initdb-postgis.sh
@@ -15,9 +15,9 @@ EOSQL
 for DB in template_postgis "$POSTGRES_DB"; do
 	echo "Loading PostGIS extensions into $DB"
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
-		CREATE EXTENSION postgis;
-		CREATE EXTENSION postgis_topology;
-		CREATE EXTENSION fuzzystrmatch;
-		CREATE EXTENSION postgis_tiger_geocoder;
+		CREATE EXTENSION IF NOT EXISTS postgis;
+		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL
 done

--- a/9.2-2.2/initdb-postgis.sh
+++ b/9.2-2.2/initdb-postgis.sh
@@ -15,9 +15,9 @@ EOSQL
 for DB in template_postgis "$POSTGRES_DB"; do
 	echo "Loading PostGIS extensions into $DB"
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
-		CREATE EXTENSION postgis;
-		CREATE EXTENSION postgis_topology;
-		CREATE EXTENSION fuzzystrmatch;
-		CREATE EXTENSION postgis_tiger_geocoder;
+		CREATE EXTENSION IF NOT EXISTS postgis;
+		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL
 done

--- a/9.3-2.2/initdb-postgis.sh
+++ b/9.3-2.2/initdb-postgis.sh
@@ -15,9 +15,9 @@ EOSQL
 for DB in template_postgis "$POSTGRES_DB"; do
 	echo "Loading PostGIS extensions into $DB"
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
-		CREATE EXTENSION postgis;
-		CREATE EXTENSION postgis_topology;
-		CREATE EXTENSION fuzzystrmatch;
-		CREATE EXTENSION postgis_tiger_geocoder;
+		CREATE EXTENSION IF NOT EXISTS postgis;
+		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL
 done

--- a/9.4-2.2/initdb-postgis.sh
+++ b/9.4-2.2/initdb-postgis.sh
@@ -15,9 +15,9 @@ EOSQL
 for DB in template_postgis "$POSTGRES_DB"; do
 	echo "Loading PostGIS extensions into $DB"
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
-		CREATE EXTENSION postgis;
-		CREATE EXTENSION postgis_topology;
-		CREATE EXTENSION fuzzystrmatch;
-		CREATE EXTENSION postgis_tiger_geocoder;
+		CREATE EXTENSION IF NOT EXISTS postgis;
+		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL
 done

--- a/9.5-2.2/initdb-postgis.sh
+++ b/9.5-2.2/initdb-postgis.sh
@@ -15,9 +15,9 @@ EOSQL
 for DB in template_postgis "$POSTGRES_DB"; do
 	echo "Loading PostGIS extensions into $DB"
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
-		CREATE EXTENSION postgis;
-		CREATE EXTENSION postgis_topology;
-		CREATE EXTENSION fuzzystrmatch;
-		CREATE EXTENSION postgis_tiger_geocoder;
+		CREATE EXTENSION IF NOT EXISTS postgis;
+		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL
 done

--- a/initdb-postgis.sh
+++ b/initdb-postgis.sh
@@ -15,9 +15,9 @@ EOSQL
 for DB in template_postgis "$POSTGRES_DB"; do
 	echo "Loading PostGIS extensions into $DB"
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
-		CREATE EXTENSION postgis;
-		CREATE EXTENSION postgis_topology;
-		CREATE EXTENSION fuzzystrmatch;
-		CREATE EXTENSION postgis_tiger_geocoder;
+		CREATE EXTENSION IF NOT EXISTS postgis;
+		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL
 done


### PR DESCRIPTION
Hi,

I just tried to add a `.sql` file to the `/docker-entrypoint-initdb.d` folder before starting the container. This executes the SQL code in the file where I also hat a `CREATE EXTENSION postgis` statement.

Now the container stopped nonzero because the `initdb-postgis.sh` is ran after the files in `/docker-entrypoint-initdb.d`.

This could be fixed, if the `initdb-postgis.sh` only tries to create the extensions with `... IF NOT EXISTS`.

I would be happy, if you merged this pull request and rebuild your images ;)

Cheers,
ubergesundheit