### PR TITLE
Ensure that postgres is the first init script.

### DIFF
--- a/9.2-2.3/Dockerfile
+++ b/9.2-2.3/Dockerfile
@@ -12,4 +12,4 @@ RUN apt-get update \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d
-COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/postgis.sh
+COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/00-postgis.sh

--- a/9.3-2.3/Dockerfile
+++ b/9.3-2.3/Dockerfile
@@ -12,4 +12,4 @@ RUN apt-get update \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d
-COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/postgis.sh
+COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/00-postgis.sh

--- a/9.4-2.3/Dockerfile
+++ b/9.4-2.3/Dockerfile
@@ -12,4 +12,4 @@ RUN apt-get update \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d
-COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/postgis.sh
+COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/00-postgis.sh

--- a/9.5-2.3/Dockerfile
+++ b/9.5-2.3/Dockerfile
@@ -12,4 +12,4 @@ RUN apt-get update \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d
-COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/postgis.sh
+COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/00-postgis.sh

--- a/9.6-2.3/Dockerfile
+++ b/9.6-2.3/Dockerfile
@@ -12,4 +12,4 @@ RUN apt-get update \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d
-COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/postgis.sh
+COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/00-postgis.sh

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -11,4 +11,4 @@ RUN apt-get update \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d
-COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/postgis.sh
+COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/00-postgis.sh


### PR DESCRIPTION
You can order more easily your scripts with the norm `00-name` and the alphabetical order.