### PR TITLE
Add alpine variants for all versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,29 @@
 ---
 language: bash
+services: docker
 
 dist: trusty
 
 env:
-  - VERSION=9.2-2.3
-  - VERSION=9.3-2.3
-  - VERSION=9.4-2.3
-  - VERSION=9.5-2.3
   - VERSION=9.6-2.3
+  - VERSION=9.6-2.3 VARIANT=alpine
+  - VERSION=9.5-2.3
+  - VERSION=9.5-2.3 VARIANT=alpine
+  - VERSION=9.4-2.3
+  - VERSION=9.4-2.3 VARIANT=alpine
+  - VERSION=9.3-2.3
+  - VERSION=9.3-2.3 VARIANT=alpine
+  - VERSION=9.2-2.3
+  - VERSION=9.2-2.3 VARIANT=alpine
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images
 
 before_script:
   - env | sort
-  - cd "$VERSION"
-  - image="appropriate/postgis:$VERSION"
+  - cd "$VERSION/$VARIANT"
+  - image="appropriate/postgis:$VERSION${VARIANT:+-${VARIANT}}"
 
 script:
   - docker build --pull -t "$image" .
-  - ~/official-images/test/run.sh -c ~/official-images/test/config.sh -c ../test/postgis-config.sh "$image"
+  - ~/official-images/test/run.sh -c ~/official-images/test/config.sh -c "../${VARIANT:+../}test/postgis-config.sh" "$image"

--- a/9.2-2.3/alpine/Dockerfile
+++ b/9.2-2.3/alpine/Dockerfile
@@ -1,0 +1,58 @@
+FROM postgres:9.2-alpine
+MAINTAINER Régis Belson <me@regisbelson.fr>
+
+ENV POSTGIS_VERSION 2.3.1
+ENV POSTGIS_SHA256 0f1e0fe08f55b6db791d8600bb343e4f77590725acbbec99094a30b8b7439cd8
+
+RUN set -ex \
+    \
+    && apk add --no-cache --virtual .fetch-deps \
+        ca-certificates \
+        openssl \
+        tar \
+    \
+    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz" \
+    && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c - \
+    && mkdir -p /usr/src/postgis \
+    && tar \
+        --extract \
+        --file postgis.tar.gz \
+        --directory /usr/src/postgis \
+        --strip-components 1 \
+    && rm postgis.tar.gz \
+    \
+    && apk add --no-cache --virtual .build-deps \
+        autoconf \
+        automake \
+        g++ \
+        json-c-dev \
+        libtool \
+        libxml2-dev \
+        make \
+        perl \
+    \
+    && apk add --no-cache --virtual .build-deps-testing \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+        gdal-dev \
+        geos-dev \
+        proj4-dev \
+    && cd /usr/src/postgis \
+    && ./autogen.sh \
+# configure options taken from:
+# https://anonscm.debian.org/cgit/pkg-grass/postgis.git/tree/debian/rules?h=jessie
+    && ./configure \
+#       --with-gui \
+    && make \
+    && make install \
+    && apk add --no-cache --virtual .postgis-rundeps \
+        json-c \
+    && apk add --no-cache --virtual .postgis-rundeps-testing \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+        geos \
+        gdal \
+        proj4 \
+    && cd / \
+    && rm -rf /usr/src/postgis \
+    && apk del .fetch-deps .build-deps .build-deps-testing
+
+COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/postgis.sh

--- a/9.2-2.3/alpine/initdb-postgis.sh
+++ b/9.2-2.3/alpine/initdb-postgis.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -e
+
+# Perform all actions as $POSTGRES_USER
+export PGUSER="$POSTGRES_USER"
+
+# Create the 'template_postgis' template db
+"${psql[@]}" <<- 'EOSQL'
+CREATE DATABASE template_postgis;
+UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+EOSQL
+
+# Load PostGIS into both template_database and $POSTGRES_DB
+for DB in template_postgis "$POSTGRES_DB"; do
+	echo "Loading PostGIS extensions into $DB"
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
+		CREATE EXTENSION IF NOT EXISTS postgis;
+		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
+EOSQL
+done

--- a/9.3-2.3/alpine/Dockerfile
+++ b/9.3-2.3/alpine/Dockerfile
@@ -1,0 +1,58 @@
+FROM postgres:9.3-alpine
+MAINTAINER Régis Belson <me@regisbelson.fr>
+
+ENV POSTGIS_VERSION 2.3.1
+ENV POSTGIS_SHA256 0f1e0fe08f55b6db791d8600bb343e4f77590725acbbec99094a30b8b7439cd8
+
+RUN set -ex \
+    \
+    && apk add --no-cache --virtual .fetch-deps \
+        ca-certificates \
+        openssl \
+        tar \
+    \
+    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz" \
+    && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c - \
+    && mkdir -p /usr/src/postgis \
+    && tar \
+        --extract \
+        --file postgis.tar.gz \
+        --directory /usr/src/postgis \
+        --strip-components 1 \
+    && rm postgis.tar.gz \
+    \
+    && apk add --no-cache --virtual .build-deps \
+        autoconf \
+        automake \
+        g++ \
+        json-c-dev \
+        libtool \
+        libxml2-dev \
+        make \
+        perl \
+    \
+    && apk add --no-cache --virtual .build-deps-testing \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+        gdal-dev \
+        geos-dev \
+        proj4-dev \
+    && cd /usr/src/postgis \
+    && ./autogen.sh \
+# configure options taken from:
+# https://anonscm.debian.org/cgit/pkg-grass/postgis.git/tree/debian/rules?h=jessie
+    && ./configure \
+#       --with-gui \
+    && make \
+    && make install \
+    && apk add --no-cache --virtual .postgis-rundeps \
+        json-c \
+    && apk add --no-cache --virtual .postgis-rundeps-testing \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+        geos \
+        gdal \
+        proj4 \
+    && cd / \
+    && rm -rf /usr/src/postgis \
+    && apk del .fetch-deps .build-deps .build-deps-testing
+
+COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/postgis.sh

--- a/9.3-2.3/alpine/initdb-postgis.sh
+++ b/9.3-2.3/alpine/initdb-postgis.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -e
+
+# Perform all actions as $POSTGRES_USER
+export PGUSER="$POSTGRES_USER"
+
+# Create the 'template_postgis' template db
+"${psql[@]}" <<- 'EOSQL'
+CREATE DATABASE template_postgis;
+UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+EOSQL
+
+# Load PostGIS into both template_database and $POSTGRES_DB
+for DB in template_postgis "$POSTGRES_DB"; do
+	echo "Loading PostGIS extensions into $DB"
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
+		CREATE EXTENSION IF NOT EXISTS postgis;
+		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
+EOSQL
+done

--- a/9.4-2.3/alpine/Dockerfile
+++ b/9.4-2.3/alpine/Dockerfile
@@ -1,0 +1,58 @@
+FROM postgres:9.4-alpine
+MAINTAINER Régis Belson <me@regisbelson.fr>
+
+ENV POSTGIS_VERSION 2.3.1
+ENV POSTGIS_SHA256 0f1e0fe08f55b6db791d8600bb343e4f77590725acbbec99094a30b8b7439cd8
+
+RUN set -ex \
+    \
+    && apk add --no-cache --virtual .fetch-deps \
+        ca-certificates \
+        openssl \
+        tar \
+    \
+    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz" \
+    && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c - \
+    && mkdir -p /usr/src/postgis \
+    && tar \
+        --extract \
+        --file postgis.tar.gz \
+        --directory /usr/src/postgis \
+        --strip-components 1 \
+    && rm postgis.tar.gz \
+    \
+    && apk add --no-cache --virtual .build-deps \
+        autoconf \
+        automake \
+        g++ \
+        json-c-dev \
+        libtool \
+        libxml2-dev \
+        make \
+        perl \
+    \
+    && apk add --no-cache --virtual .build-deps-testing \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+        gdal-dev \
+        geos-dev \
+        proj4-dev \
+    && cd /usr/src/postgis \
+    && ./autogen.sh \
+# configure options taken from:
+# https://anonscm.debian.org/cgit/pkg-grass/postgis.git/tree/debian/rules?h=jessie
+    && ./configure \
+#       --with-gui \
+    && make \
+    && make install \
+    && apk add --no-cache --virtual .postgis-rundeps \
+        json-c \
+    && apk add --no-cache --virtual .postgis-rundeps-testing \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+        geos \
+        gdal \
+        proj4 \
+    && cd / \
+    && rm -rf /usr/src/postgis \
+    && apk del .fetch-deps .build-deps .build-deps-testing
+
+COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/postgis.sh

--- a/9.4-2.3/alpine/initdb-postgis.sh
+++ b/9.4-2.3/alpine/initdb-postgis.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -e
+
+# Perform all actions as $POSTGRES_USER
+export PGUSER="$POSTGRES_USER"
+
+# Create the 'template_postgis' template db
+"${psql[@]}" <<- 'EOSQL'
+CREATE DATABASE template_postgis;
+UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+EOSQL
+
+# Load PostGIS into both template_database and $POSTGRES_DB
+for DB in template_postgis "$POSTGRES_DB"; do
+	echo "Loading PostGIS extensions into $DB"
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
+		CREATE EXTENSION IF NOT EXISTS postgis;
+		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
+EOSQL
+done

--- a/9.5-2.3/alpine/Dockerfile
+++ b/9.5-2.3/alpine/Dockerfile
@@ -1,0 +1,58 @@
+FROM postgres:9.5-alpine
+MAINTAINER Régis Belson <me@regisbelson.fr>
+
+ENV POSTGIS_VERSION 2.3.1
+ENV POSTGIS_SHA256 0f1e0fe08f55b6db791d8600bb343e4f77590725acbbec99094a30b8b7439cd8
+
+RUN set -ex \
+    \
+    && apk add --no-cache --virtual .fetch-deps \
+        ca-certificates \
+        openssl \
+        tar \
+    \
+    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz" \
+    && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c - \
+    && mkdir -p /usr/src/postgis \
+    && tar \
+        --extract \
+        --file postgis.tar.gz \
+        --directory /usr/src/postgis \
+        --strip-components 1 \
+    && rm postgis.tar.gz \
+    \
+    && apk add --no-cache --virtual .build-deps \
+        autoconf \
+        automake \
+        g++ \
+        json-c-dev \
+        libtool \
+        libxml2-dev \
+        make \
+        perl \
+    \
+    && apk add --no-cache --virtual .build-deps-testing \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+        gdal-dev \
+        geos-dev \
+        proj4-dev \
+    && cd /usr/src/postgis \
+    && ./autogen.sh \
+# configure options taken from:
+# https://anonscm.debian.org/cgit/pkg-grass/postgis.git/tree/debian/rules?h=jessie
+    && ./configure \
+#       --with-gui \
+    && make \
+    && make install \
+    && apk add --no-cache --virtual .postgis-rundeps \
+        json-c \
+    && apk add --no-cache --virtual .postgis-rundeps-testing \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+        geos \
+        gdal \
+        proj4 \
+    && cd / \
+    && rm -rf /usr/src/postgis \
+    && apk del .fetch-deps .build-deps .build-deps-testing
+
+COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/postgis.sh

--- a/9.5-2.3/alpine/initdb-postgis.sh
+++ b/9.5-2.3/alpine/initdb-postgis.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -e
+
+# Perform all actions as $POSTGRES_USER
+export PGUSER="$POSTGRES_USER"
+
+# Create the 'template_postgis' template db
+"${psql[@]}" <<- 'EOSQL'
+CREATE DATABASE template_postgis;
+UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+EOSQL
+
+# Load PostGIS into both template_database and $POSTGRES_DB
+for DB in template_postgis "$POSTGRES_DB"; do
+	echo "Loading PostGIS extensions into $DB"
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
+		CREATE EXTENSION IF NOT EXISTS postgis;
+		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
+EOSQL
+done

--- a/9.6-2.3/alpine/Dockerfile
+++ b/9.6-2.3/alpine/Dockerfile
@@ -1,0 +1,58 @@
+FROM postgres:9.6-alpine
+MAINTAINER Régis Belson <me@regisbelson.fr>
+
+ENV POSTGIS_VERSION 2.3.1
+ENV POSTGIS_SHA256 0f1e0fe08f55b6db791d8600bb343e4f77590725acbbec99094a30b8b7439cd8
+
+RUN set -ex \
+    \
+    && apk add --no-cache --virtual .fetch-deps \
+        ca-certificates \
+        openssl \
+        tar \
+    \
+    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz" \
+    && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c - \
+    && mkdir -p /usr/src/postgis \
+    && tar \
+        --extract \
+        --file postgis.tar.gz \
+        --directory /usr/src/postgis \
+        --strip-components 1 \
+    && rm postgis.tar.gz \
+    \
+    && apk add --no-cache --virtual .build-deps \
+        autoconf \
+        automake \
+        g++ \
+        json-c-dev \
+        libtool \
+        libxml2-dev \
+        make \
+        perl \
+    \
+    && apk add --no-cache --virtual .build-deps-testing \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+        gdal-dev \
+        geos-dev \
+        proj4-dev \
+    && cd /usr/src/postgis \
+    && ./autogen.sh \
+# configure options taken from:
+# https://anonscm.debian.org/cgit/pkg-grass/postgis.git/tree/debian/rules?h=jessie
+    && ./configure \
+#       --with-gui \
+    && make \
+    && make install \
+    && apk add --no-cache --virtual .postgis-rundeps \
+        json-c \
+    && apk add --no-cache --virtual .postgis-rundeps-testing \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+        geos \
+        gdal \
+        proj4 \
+    && cd / \
+    && rm -rf /usr/src/postgis \
+    && apk del .fetch-deps .build-deps .build-deps-testing
+
+COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/postgis.sh

--- a/9.6-2.3/alpine/initdb-postgis.sh
+++ b/9.6-2.3/alpine/initdb-postgis.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -e
+
+# Perform all actions as $POSTGRES_USER
+export PGUSER="$POSTGRES_USER"
+
+# Create the 'template_postgis' template db
+"${psql[@]}" <<- 'EOSQL'
+CREATE DATABASE template_postgis;
+UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+EOSQL
+
+# Load PostGIS into both template_database and $POSTGRES_DB
+for DB in template_postgis "$POSTGRES_DB"; do
+	echo "Loading PostGIS extensions into $DB"
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
+		CREATE EXTENSION IF NOT EXISTS postgis;
+		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
+EOSQL
+done

--- a/Dockerfile.alpine.template
+++ b/Dockerfile.alpine.template
@@ -1,0 +1,58 @@
+FROM postgres:%%PG_MAJOR%%-alpine
+MAINTAINER Régis Belson <me@regisbelson.fr>
+
+ENV POSTGIS_VERSION %%POSTGIS_VERSION%%
+ENV POSTGIS_SHA256 %%POSTGIS_SHA256%%
+
+RUN set -ex \
+    \
+    && apk add --no-cache --virtual .fetch-deps \
+        ca-certificates \
+        openssl \
+        tar \
+    \
+    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz" \
+    && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c - \
+    && mkdir -p /usr/src/postgis \
+    && tar \
+        --extract \
+        --file postgis.tar.gz \
+        --directory /usr/src/postgis \
+        --strip-components 1 \
+    && rm postgis.tar.gz \
+    \
+    && apk add --no-cache --virtual .build-deps \
+        autoconf \
+        automake \
+        g++ \
+        json-c-dev \
+        libtool \
+        libxml2-dev \
+        make \
+        perl \
+    \
+    && apk add --no-cache --virtual .build-deps-testing \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+        gdal-dev \
+        geos-dev \
+        proj4-dev \
+    && cd /usr/src/postgis \
+    && ./autogen.sh \
+# configure options taken from:
+# https://anonscm.debian.org/cgit/pkg-grass/postgis.git/tree/debian/rules?h=jessie
+    && ./configure \
+#       --with-gui \
+    && make \
+    && make install \
+    && apk add --no-cache --virtual .postgis-rundeps \
+        json-c \
+    && apk add --no-cache --virtual .postgis-rundeps-testing \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+        geos \
+        gdal \
+        proj4 \
+    && cd / \
+    && rm -rf /usr/src/postgis \
+    && apk del .fetch-deps .build-deps .build-deps-testing
+
+COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/postgis.sh

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ build: $(VERSIONS)
 
 define postgis-version
 $1:
-	docker build -t mdillon/postgis:$(shell echo $1 | sed -e 's/\//-/g') $1
+	docker build -t mdillon/postgis:$(shell echo $1 | sed -e 's/-.*//g') $1
+	docker build -t mdillon/postgis:$(shell echo $1 | sed -e 's/-.*//g')-alpine $1/alpine
 endef
 $(foreach version,$(VERSIONS),$(eval $(call postgis-version,$(version))))
 

--- a/update.sh
+++ b/update.sh
@@ -14,6 +14,7 @@ packagesUrl='http://apt.postgresql.org/pub/repos/apt/dists/jessie-pgdg/main/bina
 packages="$(echo "$packagesUrl" | sed -r 's/[^a-zA-Z.-]+/-/g')"
 curl -sSL "${packagesUrl}.bz2" | bunzip2 > "$packages"
 
+travisEnv=
 for version in "${versions[@]}"; do
 	IFS=- read pg_major postgis_major <<< "$version"
 	fullVersion="$(grep -m1 -A10 "^Package: postgresql-$pg_major-postgis-$postgis_major\$" "$packages" | grep -m1 '^Version: ' | cut -d' ' -f2)"
@@ -24,6 +25,25 @@ for version in "${versions[@]}"; do
 		mv "$version/Dockerfile.template" "$version/Dockerfile"
 		sed -i 's/%%PG_MAJOR%%/'$pg_major'/g; s/%%POSTGIS_MAJOR%%/'$postgis_major'/g; s/%%POSTGIS_VERSION%%/'$fullVersion'/g' "$version/Dockerfile"
 	)
+
+	srcVersion="${fullVersion%%+*}"
+	srcSha256="$(curl -sSL "https://github.com/postgis/postgis/archive/$srcVersion.tar.gz" | sha256sum | awk '{ print $1 }')"
+	for variant in alpine; do
+		if [ ! -d "$version/$variant" ]; then
+			continue
+		fi
+		(
+			set -x
+			cp Dockerfile.alpine.template initdb-postgis.sh "$version/$variant/"
+			mv "$version/$variant/Dockerfile.alpine.template" "$version/$variant/Dockerfile"
+			sed -i 's/%%PG_MAJOR%%/'"$pg_major"'/g; s/%%POSTGIS_VERSION%%/'"$srcVersion"'/g; s/%%POSTGIS_SHA256%%/'"$srcSha256"'/g' "$version/$variant/Dockerfile"
+		)
+		travisEnv="\n  - VERSION=$version VARIANT=$variant$travisEnv"
+	done
+
+	travisEnv='\n  - VERSION='"$version$travisEnv"
 done
+travis="$(awk -v 'RS=\n\n' '$1 == "env:" { $0 = "env:'"$travisEnv"'" } { printf "%s%s", $0, RS }' .travis.yml)"
+echo "$travis" > .travis.yml
 
 rm "$packages"


### PR DESCRIPTION
Closes #46.
The lib problem in the official postgres images is fixed (see https://github.com/docker-library/postgres/pull/247) so this is quite easy now.

```
REPOSITORY                     TAG                                                IMAGE ID            CREATED             SIZE
mdillon/postgis                9.6-alpine                                         53a1f7e01625        22 seconds ago      142 MB
mdillon/postgis                9.5-alpine                                         e0e41225988c        About an hour ago   141 MB
mdillon/postgis                9.4-alpine                                         1c426f081373        About an hour ago   140 MB
mdillon/postgis                9.3-alpine                                         2388d69ad1aa        About an hour ago   141 MB
mdillon/postgis                9.2-alpine                                         d7b194ba6708        About an hour ago   138 MB
mdillon/postgis                9.6                                                fbe7560da048        About an hour ago   602 MB
mdillon/postgis                9.5                                                3b3bb87c0d2f        About an hour ago   601 MB
mdillon/postgis                9.4                                                9ab26df15651        About an hour ago   602 MB
mdillon/postgis                9.3                                                b5b1f0aede00        About an hour ago   598 MB
mdillon/postgis                9.2                                                1aea15f840e3        About an hour ago   598 MB
```