### PR TITLE
update postgis to latest version

### DIFF
--- a/9.6-2.3/Dockerfile
+++ b/9.6-2.3/Dockerfile
@@ -2,7 +2,7 @@ FROM postgres:9.6
 MAINTAINER Mike Dillon <mike@appropriate.io>
 
 ENV POSTGIS_MAJOR 2.3
-ENV POSTGIS_VERSION 2.3.1+dfsg-1.pgdg80+1
+ENV POSTGIS_VERSION 2.3.2+dfsg-1~exp1.pgdg80+1
 
 RUN apt-get update \
       && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Like #47 and #48 

$ docker build failed with 
```
Fetched 10.0 MB in 2s (3,581 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
E: Version '2.3.1+dfsg-1.pgdg80+1' for 'postgresql-9.6-postgis-2.3' was not found
E: Version '2.3.1+dfsg-1.pgdg80+1' for 'postgresql-9.6-postgis-2.3-scripts' was not found
E: Version '2.3.1+dfsg-1.pgdg80+1' for 'postgis' was not found
```

updated POSTGIS_VERSION to `2.3.2+dfsg-1~exp1.pgdg80+1`