### PR TITLE
Add libcrypto1.1 for gdal dependency

### DIFF
--- a/10-2.5/alpine/Dockerfile
+++ b/10-2.5/alpine/Dockerfile
@@ -34,7 +34,7 @@ RUN set -ex \
     # add libcrypto from (edge:main) for gdal-2.3.0
     && apk add --no-cache --virtual .crypto-rundeps \
         --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
-        libressl2.7-libcrypto \
+        libressl2.7-libcrypto libcrypto1.1 \
     && apk add --no-cache --virtual .build-deps-testing \
         --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
         gdal-dev \

--- a/11-2.5/alpine/Dockerfile
+++ b/11-2.5/alpine/Dockerfile
@@ -34,7 +34,7 @@ RUN set -ex \
     # add libcrypto from (edge:main) for gdal-2.3.0
     && apk add --no-cache --virtual .crypto-rundeps \
         --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
-        libressl2.7-libcrypto \
+        libressl2.7-libcrypto libcrypto1.1 \
     && apk add --no-cache --virtual .build-deps-testing \
         --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
         gdal-dev \

--- a/9.4-2.5/alpine/Dockerfile
+++ b/9.4-2.5/alpine/Dockerfile
@@ -34,7 +34,7 @@ RUN set -ex \
     # add libcrypto from (edge:main) for gdal-2.3.0
     && apk add --no-cache --virtual .crypto-rundeps \
         --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
-        libressl2.7-libcrypto \
+        libressl2.7-libcrypto libcrypto1.1 \
     && apk add --no-cache --virtual .build-deps-testing \
         --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
         gdal-dev \

--- a/9.5-2.5/alpine/Dockerfile
+++ b/9.5-2.5/alpine/Dockerfile
@@ -34,7 +34,7 @@ RUN set -ex \
     # add libcrypto from (edge:main) for gdal-2.3.0
     && apk add --no-cache --virtual .crypto-rundeps \
         --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
-        libressl2.7-libcrypto \
+        libressl2.7-libcrypto libcrypto1.1 \
     && apk add --no-cache --virtual .build-deps-testing \
         --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
         gdal-dev \

--- a/9.6-2.5/alpine/Dockerfile
+++ b/9.6-2.5/alpine/Dockerfile
@@ -34,7 +34,7 @@ RUN set -ex \
     # add libcrypto from (edge:main) for gdal-2.3.0
     && apk add --no-cache --virtual .crypto-rundeps \
         --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
-        libressl2.7-libcrypto \
+        libressl2.7-libcrypto libcrypto1.1 \
     && apk add --no-cache --virtual .build-deps-testing \
         --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
         gdal-dev \


### PR DESCRIPTION
```
ERROR: unsatisfiable constraints:
  so:libcrypto.so.1.1 (missing):
    required by:
                 gdal-2.3.2-r1[so:libcrypto.so.1.1]
```