### PR TITLE
update postgres version from 10 to 10.9 due to a critical security bug

### DIFF
--- a/10-2.5/Dockerfile
+++ b/10-2.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:10
+FROM postgres:10.9
 MAINTAINER Mike Dillon <mike@appropriate.io>
 
 ENV POSTGIS_MAJOR 2.5

--- a/10-2.5/alpine/Dockerfile
+++ b/10-2.5/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:10-alpine
+FROM postgres:10.9-alpine
 MAINTAINER Régis Belson <me@regisbelson.fr>
 
 ENV POSTGIS_VERSION 2.5.2


### PR DESCRIPTION
A critical security vulnerability was found in postgres 10, 11 and 12. The community is recommending upgrading postgres `10` to `10.9`. For more information please see this link to [postgresql.org](https://www.postgresql.org/about/news/1949/) 